### PR TITLE
Clarify fentanyl units

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # opioid-converter
+
+This project provides a small example converter for opioid dosing. The
+assumption used here is that **fentanyl doses should be entered in
+micrograms (mcg)**. Internally the conversion assumes 1 mcg of fentanyl is
+approximately equivalent to 0.3&nbsp;mg of oral morphine.
+
+Example usage:
+
+```bash
+python3 opioid_converter.py 50
+```
+
+The command above interprets `50` as `50 mcg` of fentanyl and outputs the
+approximate equivalent in oral morphine milligrams.

--- a/opioid_converter.py
+++ b/opioid_converter.py
@@ -1,0 +1,36 @@
+"""Opioid dose converter.
+
+Assumption: Fentanyl input should be provided in micrograms (mcg).
+The converter uses 100 mcg IV fentanyl = 10 mg IV morphine.
+This equals 30 mg oral morphine.
+Thus, 1 mcg fentanyl ~ 0.3 mg oral morphine equivalent (OME).
+"""
+
+FENTANYL_TO_OME_MG = 0.3  # mg oral morphine equivalent per mcg fentanyl
+
+
+def fentanyl_to_ome(fentanyl_mcg: float) -> float:
+    """Convert fentanyl dose in micrograms to oral morphine equivalents (mg).
+
+    Parameters
+    ----------
+    fentanyl_mcg : float
+        Dose of fentanyl in micrograms.
+
+    Returns
+    -------
+    float
+        Equivalent dose in oral morphine milligrams.
+    """
+    return fentanyl_mcg * FENTANYL_TO_OME_MG
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Convert fentanyl mcg to oral morphine mg.")
+    parser.add_argument("mcg", type=float, help="Fentanyl dose in micrograms (mcg)")
+    args = parser.parse_args()
+    ome = fentanyl_to_ome(args.mcg)
+    print(f"{args.mcg} mcg fentanyl is approximately {ome:.2f} mg oral morphine equivalent")
+


### PR DESCRIPTION
## Summary
- add a simple fentanyl conversion script
- clarify in README that fentanyl must be provided in mcg
- document the mcg assumption in code comments

## Testing
- `pytest -q`
- `python3 opioid_converter.py 50`


------
https://chatgpt.com/codex/tasks/task_e_684a66591c80833290219bef8e949fb6